### PR TITLE
Fixed disk usage display, disk and network activity, fan speed percen…

### DIFF
--- a/etc/rockpi-sata.conf
+++ b/etc/rockpi-sata.conf
@@ -34,3 +34,17 @@ time = 10
 # Whether rotate the text of oled 180 degrees, whether use Fahrenheit
 rotate = false
 f-temp = false
+
+[disk]
+# Mount points for disks to show space usage (separated with |)
+space_usage_mnt_points = /mnt/raid1|/mnt/torrent|/mnt/torrent2
+
+# Mount points for disks to show I/O usage (separated with |)
+# Leave it blank (after the =) if you don't want to use it
+io_usage_mnt_points =
+
+[network]
+# Name of the interfaces which should be measured (separated with |)
+# Leave it blank (after the =) if you don't want to use it
+# Option 'auto' means select them automatically by their link status (every interface which link status is UP)
+interfaces =

--- a/usr/bin/rockpi-sata/misc.py
+++ b/usr/bin/rockpi-sata/misc.py
@@ -16,12 +16,13 @@ GPIO.output(17, GPIO.HIGH)
 
 cmds = {
     'blk': "lsblk | awk '{print $1}'",
-    'up': "echo Uptime: `uptime | sed 's/.*up \\([^,]*\\), .*/\\1/'`",
+    #'up': "echo Uptime: `uptime | sed 's/.*up \\([^,]*\\), .*/\\1/'`",
+    'up': "echo Up: $(uptime -p | sed 's/ years,/y/g;s/ year,/y/g;s/ months,/m/g;s/ month,/m/g;s/ weeks,/w/g;s/ week,/w/g;s/ days,/d/g;s/ day,/d/g;s/ hours,/h/g;s/ hour,/h/g;s/ minutes/m/g;s/ minute/m/g' | cut -d ' ' -f2-)",
     'temp': "cat /sys/class/thermal/thermal_zone0/temp",
     'ip': "hostname -I | awk '{printf \"IP %s\", $1}'",
-    'cpu': "uptime | awk '{printf \"CPU Load: %.2f\", $(NF-2)}'",
-    'men': "free -m | awk 'NR==2{printf \"Mem: %s/%sMB\", $3,$2}'",
-    'disk': "df -h | awk '$NF==\"/\"{printf \"Disk: %d/%dGB %s\", $3,$2,$5}'"
+    'cpu': "uptime | tr , . | awk '{printf \"CPU Load: %.2f%%\", $(NF-2)}'",
+    'men': "free -m | awk 'NR==2{printf \"Mem: %s/%s MB\", $3,$2}'",
+    'disk': "df -h | awk '$NF==\"/\"{printf \"Disk: %d/%d GB %s\", $3,$2,$5}'"
 }
 
 lv2dc = {'lv3': 100, 'lv2': 75, 'lv1': 50, 'lv0': 25}
@@ -37,13 +38,13 @@ def set_mode(pin, mode):
 
 
 def disk_turn_on():
-    blk1 = get_blk()
+    #blk1 = get_blk()
     set_mode(26, GPIO.HIGH)
     time.sleep(0.5)
     set_mode(25, GPIO.HIGH)
     wait_blk(10)
-    blk2 = get_blk()
-    conf['disk'] = sorted(list(set(blk2) - set(blk1)))
+    #blk2 = get_blk()
+    #conf['disk'] = sorted(list(set(blk2) - set(blk1)))
 
 
 def disk_turn_off():
@@ -117,6 +118,12 @@ def read_conf():
         conf['slider']['time'] = cfg.getfloat('slider', 'time')
         conf['oled']['rotate'] = cfg.getboolean('oled', 'rotate')
         conf['oled']['f-temp'] = cfg.getboolean('oled', 'f-temp')
+        # disk
+        conf['disk']['space_usage_mnt_points'] = cfg.get('disk', 'space_usage_mnt_points').split('|')
+        conf['disk']['io_usage_mnt_points'] = cfg.get('disk', 'io_usage_mnt_points').split('|')
+        #conf['disk']['disks'] = get_disk_list()
+        # network
+        conf['network']['interfaces'] = cfg.get('network', 'interfaces').split('|')
     except Exception:
         # fan
         conf['fan']['lv0'] = 35
@@ -135,6 +142,12 @@ def read_conf():
         conf['slider']['time'] = 10  # second
         conf['oled']['rotate'] = False
         conf['oled']['f-temp'] = False
+        # disk
+        conf['disk']['space_usage_mnt_points'] = []
+        conf['disk']['io_usage_mnt_points'] = []
+        #conf['disk']['disks'] = []
+        # network
+        conf['network']['interfaces'] = []
 
     return conf
 
@@ -162,12 +175,80 @@ def watch_key(q=None):
         q.put(read_key(pattern, size))
 
 
+def get_interface_list():
+    if len(conf['network']['interfaces']) == 1 and conf['network']['interfaces'][0] == '':
+        return []
+
+    if len(conf['network']['interfaces']) == 1 and conf['network']['interfaces'][0] == 'auto':
+        interfaces = []
+        cmd = "ip -o link show | awk '{print $2,$9}'"
+        list = check_output(cmd).split('\n')
+        for x in list:
+            name_status = x.split(': ')
+            if "UP" in name_status[1]:
+                interfaces.append(name_status[0])
+
+        interfaces.sort()
+
+    else:
+        interfaces = conf['network']['interfaces']
+
+    return interfaces
+
+
+def get_interface_rx_info(interface):
+    cmd = "R1=$(cat /sys/class/net/" + interface + "/statistics/rx_bytes); sleep 1; R2=$(cat /sys/class/net/" + interface + "/statistics/rx_bytes); echo | awk -v r1=$R1 -v r2=$R2 '{printf \"rx: %.5f MB/s\", (r2 - r1) / 1024 / 1024}';"
+    output = check_output(cmd)
+    return output
+
+
+def get_interface_tx_info(interface):
+    cmd = "T1=$(cat /sys/class/net/" + interface + "/statistics/tx_bytes); sleep 1; T2=$(cat /sys/class/net/" + interface + "/statistics/tx_bytes); echo | awk -v t1=$T1 -v t2=$T2 '{printf \"tx: %.5f MB/s\", (t2 - t1) / 1024 / 1024}';"
+    output = check_output(cmd)
+    return output
+
+
+def delete_disk_partition_number(disk):
+    if "sd" in disk:
+        disk = disk[:-1]
+    return disk
+
+
+def get_disk_list(type):
+    if len(conf['disk'][type]) == 1 and conf['disk'][type][0] == '':
+        return []
+
+    disks = []
+    for x in conf['disk'][type]:
+        cmd = "df -Bg | awk '$6==\"{}\" {{printf \"%s\", $1}}'".format(x)
+        output = check_output(cmd).split('/')[-1]
+        if output != '':
+            disks.append(output)
+
+    disks.sort()
+    return disks
+
+
+def get_disk_io_read_info(disk):
+    cmd = "R1=$(cat /sys/block/" + disk + "/stat | awk '{print $3}'); sleep 1; R2=$(cat /sys/block/" + disk + "/stat | awk '{print $3}'); echo | awk -v r1=$R1 -v r2=$R2 '{printf \"R: %.5f MB/s\", (r2 - r1) / 2 / 1024}';"
+    output = check_output(cmd)
+    return output
+
+
+def get_disk_io_write_info(disk):
+    cmd = "W1=$(cat /sys/block/" + disk + "/stat | awk '{print $7}'); sleep 1; W2=$(cat /sys/block/" + disk + "/stat | awk '{print $7}'); echo | awk -v w1=$W1 -v w2=$W2 '{printf \"W: %.5f MB/s\", (w2 - w1) / 2 / 1024}';"
+    output = check_output(cmd)
+    return output
+
+
 def get_disk_info(cache={}):
     if not cache.get('time') or time.time() - cache['time'] > 30:
         info = {}
         cmd = "df -h | awk '$NF==\"/\"{printf \"%s\", $5}'"
         info['root'] = check_output(cmd)
-        for x in conf['disk']:
+        conf['disk']['disks'] = get_disk_list('space_usage_mnt_points')
+        for x in conf['disk']['disks']:
+            delete_disk_partition_number(x)
             cmd = "df -Bg | awk '$1==\"/dev/{}\" {{printf \"%s\", $5}}'".format(x)
             info[x] = check_output(cmd)
         cache['info'] = list(zip(*info.items()))

--- a/usr/bin/rockpi-sata/oled.py
+++ b/usr/bin/rockpi-sata/oled.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 import time
 import misc
+import fan
 import Adafruit_SSD1306
 from PIL import Image
 from PIL import ImageDraw
@@ -44,12 +45,12 @@ def disp_show():
 
 def welcome():
     draw.text((0, 0), 'ROCK Pi SATA HAT', font=font['14'], fill=255)
-    draw.text((32, 16), 'loading...', font=font['12'], fill=255)
+    draw.text((32, 16), 'Loading...', font=font['12'], fill=255)
     disp_show()
 
 
 def goodbye():
-    draw.text((32, 8), 'Good Bye ~', font=font['14'], fill=255)
+    draw.text((30, 8), 'Power off...', font=font['14'], fill=255)
     disp_show()
     time.sleep(2)
     disp_show()  # clear
@@ -67,8 +68,22 @@ def put_disk_info():
             {'xy': (0, 10), 'text': text2, 'fill': 255, 'font': font['11']},
             {'xy': (0, 21), 'text': text3, 'fill': 255, 'font': font['11']},
         ]
+    elif len(k) == 4:
+        text2 = '{} {}  {} {}'.format(k[1], v[1], k[2], v[2])
+        text3 = '{} {}'.format(k[3], v[3])
+        page = [
+            {'xy': (0, -2), 'text': text1, 'fill': 255, 'font': font['11']},
+            {'xy': (0, 10), 'text': text2, 'fill': 255, 'font': font['11']},
+            {'xy': (0, 21), 'text': text3, 'fill': 255, 'font': font['11']},
+        ]
     elif len(k) == 3:
         text2 = '{} {}  {} {}'.format(k[1], v[1], k[2], v[2])
+        page = [
+            {'xy': (0, 2), 'text': text1, 'fill': 255, 'font': font['12']},
+            {'xy': (0, 18), 'text': text2, 'fill': 255, 'font': font['12']},
+        ]
+    elif len(k) == 2:
+        text2 = '{} {}'.format(k[1], v[1])
         page = [
             {'xy': (0, 2), 'text': text1, 'fill': 255, 'font': font['12']},
             {'xy': (0, 18), 'text': text2, 'fill': 255, 'font': font['12']},
@@ -79,19 +94,59 @@ def put_disk_info():
     return page
 
 
+def put_disk_io_info(pages_len):
+    pages = {}
+    page_index = pages_len
+    disks = misc.get_disk_list('io_usage_mnt_points')
+
+    for x in disks:
+        x = misc.delete_disk_partition_number(x)
+
+        pages[page_index] = [
+            {'xy': (0, -2), 'text': 'Disk (' + x + '):', 'fill': 255, 'font': font['11']},
+            {'xy': (0, 10), 'text': misc.get_disk_io_read_info(x), 'fill': 255, 'font': font['11']},
+            {'xy': (0, 21), 'text': misc.get_disk_io_write_info(x), 'fill': 255, 'font': font['11']}
+        ]
+        page_index = page_index + 1
+
+    return pages
+
+
+def put_interface_info(pages_len):
+    pages = {}
+    page_index = pages_len
+    interfaces = misc.get_interface_list()
+
+    for x in interfaces:
+        pages[page_index] = [
+            {'xy': (0, -2), 'text': 'Network (' + x + '):', 'fill': 255, 'font': font['11']},
+            {'xy': (0, 10), 'text': misc.get_interface_rx_info(x), 'fill': 255, 'font': font['11']},
+            {'xy': (0, 21), 'text': misc.get_interface_tx_info(x), 'fill': 255, 'font': font['11']}
+        ]
+        page_index = page_index + 1
+
+    return pages
+
+
 def gen_pages():
     pages = {
         0: [
             {'xy': (0, -2), 'text': misc.get_info('up'), 'fill': 255, 'font': font['11']},
             {'xy': (0, 10), 'text': misc.get_cpu_temp(), 'fill': 255, 'font': font['11']},
-            {'xy': (0, 21), 'text': misc.get_info('ip'), 'fill': 255, 'font': font['11']},
+            {'xy': (0, 21), 'text': misc.get_info('ip'), 'fill': 255, 'font': font['11']}
         ],
         1: [
-            {'xy': (0, 2), 'text': misc.get_info('cpu'), 'fill': 255, 'font': font['12']},
-            {'xy': (0, 18), 'text': misc.get_info('men'), 'fill': 255, 'font': font['12']},
+            #{'xy': (0, 2), 'text': misc.get_info('cpu'), 'fill': 255, 'font': font['12']},
+            #{'xy': (0, 18), 'text': misc.get_info('men'), 'fill': 255, 'font': font['12']}
+            {'xy': (0, -2), 'text': 'Fan speed: ' + str(fan.get_dc()) + '%', 'fill': 255, 'font': font['11']},
+            {'xy': (0, 10), 'text': misc.get_info('cpu'), 'fill': 255, 'font': font['11']},
+            {'xy': (0, 21), 'text': misc.get_info('men'), 'fill': 255, 'font': font['11']},
         ],
         2: put_disk_info()
     }
+
+    pages.update(put_interface_info(len(pages)))
+    pages.update(put_disk_io_info(len(pages)))
 
     return pages
 


### PR DESCRIPTION
- Fixed CPU usage separator, because of some locales use , (comma) to decimail point instead of . (dot), but AWK uses . (dot).
- Fixed "Only show root" issue (replaced with a manually list which can given in rockpi-sata.conf).
- Improved uptime display (use shorter words like day = d, minute = m), so more detaill can be read from the OLED panel.
- Added Fan Speed display to OLED panel.
- Added Disk I/O activity display to OLED panel.
- Added Network activity display to OLED panel.
- You can select manually via mount points which disks should display space usage.
- You can select manually via mount points which disks should display the I/O usage, or you can disable this feature.
- You can select manually which network interface usage should display, or you can let the program to choose automatically by the link status of interface (UP is selected) or you can disable this feature.
