### PR TITLE
Expand number of fan levels, improve code

### DIFF
--- a/etc/rockpi-sata.conf
+++ b/etc/rockpi-sata.conf
@@ -1,12 +1,16 @@
 [fan]
-# When the temperature is above lv0 (35'C), the fan at 25% power,
-# and lv1 at 50% power, lv2 at 75% power, lv3 at 100% power.
+# When the temperature is above lv0 (35'C), the fan at 12% power,
+# and lv1 at 25% power, lv2 at 37% power, etc. up to lv7 at 100% power.
 # When the temperature is below lv0, the fan is turned off.
 # You can change these values if necessary.
 lv0 = 35
-lv1 = 40
-lv2 = 45
-lv3 = 50
+lv1 = 37
+lv2 = 40
+lv3 = 42
+lv4 = 44
+lv5 = 46
+lv6 = 48
+lv7 = 50
 
 [key]
 # You can customize the function of the key, currently available functions are

--- a/usr/bin/rockpi-sata/misc.py
+++ b/usr/bin/rockpi-sata/misc.py
@@ -25,7 +25,16 @@ cmds = {
     'disk': "df -h | awk '$NF==\"/\"{printf \"Disk: %d/%d GB %s\", $3,$2,$5}'"
 }
 
-lv2dc = {'lv3': 100, 'lv2': 75, 'lv1': 50, 'lv0': 25}
+lv2dc = {
+    'lv7': 100,
+    'lv6': 87,
+    'lv5': 75,
+    'lv4': 62,
+    'lv3': 50,
+    'lv2': 37,
+    'lv1': 25,
+    'lv0': 12,
+}
 
 
 # pin37(bcm26) sata0, pin22(bcm25) sata1
@@ -102,10 +111,26 @@ def read_conf():
         cfg = ConfigParser()
         cfg.read('/etc/rockpi-sata.conf')
         # fan
-        conf['fan']['lv0'] = cfg.getfloat('fan', 'lv0')
-        conf['fan']['lv1'] = cfg.getfloat('fan', 'lv1')
-        conf['fan']['lv2'] = cfg.getfloat('fan', 'lv2')
-        conf['fan']['lv3'] = cfg.getfloat('fan', 'lv3')
+        # Reverse compatibility for old configs
+        # If none of the new values are found in the cfg
+        if set(['lv4', 'lv5', 'lv6', 'lv7']) & set(cfg['fan'].keys()):
+            conf['fan']['lv0'] = cfg.getfloat('fan', 'lv0')
+            conf['fan']['lv1'] = cfg.getfloat('fan', 'lv0')
+            conf['fan']['lv2'] = cfg.getfloat('fan', 'lv1')
+            conf['fan']['lv3'] = cfg.getfloat('fan', 'lv1')
+            conf['fan']['lv4'] = cfg.getfloat('fan', 'lv2')
+            conf['fan']['lv5'] = cfg.getfloat('fan', 'lv2')
+            conf['fan']['lv6'] = cfg.getfloat('fan', 'lv3')
+            conf['fan']['lv7'] = cfg.getfloat('fan', 'lv3')
+        else:
+            conf['fan']['lv0'] = cfg.getfloat('fan', 'lv0')
+            conf['fan']['lv1'] = cfg.getfloat('fan', 'lv1')
+            conf['fan']['lv2'] = cfg.getfloat('fan', 'lv2')
+            conf['fan']['lv3'] = cfg.getfloat('fan', 'lv3')
+            conf['fan']['lv4'] = cfg.getfloat('fan', 'lv4')
+            conf['fan']['lv5'] = cfg.getfloat('fan', 'lv5')
+            conf['fan']['lv6'] = cfg.getfloat('fan', 'lv6')
+            conf['fan']['lv7'] = cfg.getfloat('fan', 'lv7')
         # key
         conf['key']['click'] = cfg.get('key', 'click')
         conf['key']['twice'] = cfg.get('key', 'twice')
@@ -127,9 +152,13 @@ def read_conf():
     except Exception:
         # fan
         conf['fan']['lv0'] = 35
-        conf['fan']['lv1'] = 40
-        conf['fan']['lv2'] = 45
-        conf['fan']['lv3'] = 50
+        conf['fan']['lv1'] = 37
+        conf['fan']['lv2'] = 40
+        conf['fan']['lv3'] = 42
+        conf['fan']['lv4'] = 44
+        conf['fan']['lv5'] = 46
+        conf['fan']['lv6'] = 48
+        conf['fan']['lv7'] = 50
         # key
         conf['key']['click'] = 'slider'
         conf['key']['twice'] = 'switch'

--- a/usr/bin/rockpi-sata/misc.py
+++ b/usr/bin/rockpi-sata/misc.py
@@ -107,10 +107,10 @@ def get_cpu_temp():
 def read_conf():
     conf = defaultdict(dict)
 
+    cfg = ConfigParser()
+    cfg.read('/etc/rockpi-sata.conf')
+    # fan
     try:
-        cfg = ConfigParser()
-        cfg.read('/etc/rockpi-sata.conf')
-        # fan
         # Reverse compatibility for old configs
         # If none of the new values are found in the cfg
         if set(['lv4', 'lv5', 'lv6', 'lv7']) & set(cfg['fan'].keys()):
@@ -131,26 +131,7 @@ def read_conf():
             conf['fan']['lv5'] = cfg.getfloat('fan', 'lv5')
             conf['fan']['lv6'] = cfg.getfloat('fan', 'lv6')
             conf['fan']['lv7'] = cfg.getfloat('fan', 'lv7')
-        # key
-        conf['key']['click'] = cfg.get('key', 'click')
-        conf['key']['twice'] = cfg.get('key', 'twice')
-        conf['key']['press'] = cfg.get('key', 'press')
-        # time
-        conf['time']['twice'] = cfg.getfloat('time', 'twice')
-        conf['time']['press'] = cfg.getfloat('time', 'press')
-        # other
-        conf['slider']['auto'] = cfg.getboolean('slider', 'auto')
-        conf['slider']['time'] = cfg.getfloat('slider', 'time')
-        conf['oled']['rotate'] = cfg.getboolean('oled', 'rotate')
-        conf['oled']['f-temp'] = cfg.getboolean('oled', 'f-temp')
-        # disk
-        conf['disk']['space_usage_mnt_points'] = cfg.get('disk', 'space_usage_mnt_points').split('|')
-        conf['disk']['io_usage_mnt_points'] = cfg.get('disk', 'io_usage_mnt_points').split('|')
-        #conf['disk']['disks'] = get_disk_list()
-        # network
-        conf['network']['interfaces'] = cfg.get('network', 'interfaces').split('|')
     except Exception:
-        # fan
         conf['fan']['lv0'] = 35
         conf['fan']['lv1'] = 37
         conf['fan']['lv2'] = 40
@@ -159,23 +140,55 @@ def read_conf():
         conf['fan']['lv5'] = 46
         conf['fan']['lv6'] = 48
         conf['fan']['lv7'] = 50
-        # key
+
+    # key
+    try:
+        conf['key']['click'] = cfg.get('key', 'click')
+        conf['key']['twice'] = cfg.get('key', 'twice')
+        conf['key']['press'] = cfg.get('key', 'press')
+    except Exception:
         conf['key']['click'] = 'slider'
         conf['key']['twice'] = 'switch'
         conf['key']['press'] = 'none'
-        # time
+
+    # time
+    try:
+        conf['time']['twice'] = cfg.getfloat('time', 'twice')
+        conf['time']['press'] = cfg.getfloat('time', 'press')
+    except Exception:
         conf['time']['twice'] = 0.7  # second
         conf['time']['press'] = 1.8
-        # other
+
+    # slider
+    try:
+        conf['slider']['auto'] = cfg.getboolean('slider', 'auto')
+        conf['slider']['time'] = cfg.getfloat('slider', 'time')
+    except Exception:
         conf['slider']['auto'] = True
         conf['slider']['time'] = 10  # second
+
+    # oled
+    try:
+        conf['oled']['rotate'] = cfg.getboolean('oled', 'rotate')
+        conf['oled']['f-temp'] = cfg.getboolean('oled', 'f-temp')
+    except Exception:
         conf['oled']['rotate'] = False
         conf['oled']['f-temp'] = False
-        # disk
+
+    # disk
+    try:
+        conf['disk']['space_usage_mnt_points'] = cfg.get('disk', 'space_usage_mnt_points').split('|')
+        conf['disk']['io_usage_mnt_points'] = cfg.get('disk', 'io_usage_mnt_points').split('|')
+        #conf['disk']['disks'] = get_disk_list()
+    except Exception:
         conf['disk']['space_usage_mnt_points'] = []
         conf['disk']['io_usage_mnt_points'] = []
         #conf['disk']['disks'] = []
+
+    try:
         # network
+        conf['network']['interfaces'] = cfg.get('network', 'interfaces').split('|')
+    except Exception:
         conf['network']['interfaces'] = []
 
     return conf

--- a/usr/bin/rockpi-sata/misc.py
+++ b/usr/bin/rockpi-sata/misc.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import logging
 import re
 import os
 import sys
@@ -8,6 +9,9 @@ import RPi.GPIO as GPIO
 import multiprocessing as mp
 from collections import defaultdict
 from configparser import ConfigParser
+
+
+logger = logging.getLogger(__name__)
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)
@@ -131,7 +135,8 @@ def read_conf():
             conf['fan']['lv5'] = cfg.getfloat('fan', 'lv5')
             conf['fan']['lv6'] = cfg.getfloat('fan', 'lv6')
             conf['fan']['lv7'] = cfg.getfloat('fan', 'lv7')
-    except Exception:
+    except Exception as e:
+        logger.debug("Config parsing error: {}; using default values for fan".format(e))
         conf['fan']['lv0'] = 35
         conf['fan']['lv1'] = 37
         conf['fan']['lv2'] = 40
@@ -146,7 +151,8 @@ def read_conf():
         conf['key']['click'] = cfg.get('key', 'click')
         conf['key']['twice'] = cfg.get('key', 'twice')
         conf['key']['press'] = cfg.get('key', 'press')
-    except Exception:
+    except Exception as e:
+        logger.debug("Config parsing error: {}; using default values for button functions".format(e))
         conf['key']['click'] = 'slider'
         conf['key']['twice'] = 'switch'
         conf['key']['press'] = 'none'
@@ -155,7 +161,8 @@ def read_conf():
     try:
         conf['time']['twice'] = cfg.getfloat('time', 'twice')
         conf['time']['press'] = cfg.getfloat('time', 'press')
-    except Exception:
+    except Exception as e:
+        logger.debug("Config parsing error: {}; using default values for button press time".format(e))
         conf['time']['twice'] = 0.7  # second
         conf['time']['press'] = 1.8
 
@@ -163,7 +170,8 @@ def read_conf():
     try:
         conf['slider']['auto'] = cfg.getboolean('slider', 'auto')
         conf['slider']['time'] = cfg.getfloat('slider', 'time')
-    except Exception:
+    except Exception as e:
+        logger.debug("Config parsing error: {}; using default values for slider".format(e))
         conf['slider']['auto'] = True
         conf['slider']['time'] = 10  # second
 
@@ -171,7 +179,8 @@ def read_conf():
     try:
         conf['oled']['rotate'] = cfg.getboolean('oled', 'rotate')
         conf['oled']['f-temp'] = cfg.getboolean('oled', 'f-temp')
-    except Exception:
+    except Exception as e:
+        logger.debug("Config parsing error: {}; using default values for oled".format(e))
         conf['oled']['rotate'] = False
         conf['oled']['f-temp'] = False
 
@@ -180,7 +189,8 @@ def read_conf():
         conf['disk']['space_usage_mnt_points'] = cfg.get('disk', 'space_usage_mnt_points').split('|')
         conf['disk']['io_usage_mnt_points'] = cfg.get('disk', 'io_usage_mnt_points').split('|')
         #conf['disk']['disks'] = get_disk_list()
-    except Exception:
+    except Exception as e:
+        logger.debug("Config parsing error: {}; using default values for disk".format(e))
         conf['disk']['space_usage_mnt_points'] = []
         conf['disk']['io_usage_mnt_points'] = []
         #conf['disk']['disks'] = []
@@ -188,7 +198,8 @@ def read_conf():
     try:
         # network
         conf['network']['interfaces'] = cfg.get('network', 'interfaces').split('|')
-    except Exception:
+    except Exception as e:
+        logger.debug("Config parsing error: {}; using default values for network".format(e))
         conf['network']['interfaces'] = []
 
     return conf


### PR DESCRIPTION
1. This PR expands the number of fan levels from 4 to eight, since the previous fan levels would transition from quiet to very audible. This change makes the fan much quieter.

   I made sure to keep compatibility with previous config files, so if `lv4`, `lv5`, `lv6`, and `lv7` are not all found in the configuration, it will use the values from `lv0`, `lv1`, lv2`, and `lv3` as before.
2. I broke up the `try`/`except` block into multiple `try`/`except` blocks, that way a misconfiguration in one section will only cause that section to revert to default values and sections that do have valid configurations will keep those values.
3. I also added some initial logging. That way the user has some idea over what section was misconfigured.