### PR TITLE
Fixed wrongly deleted sd string name.

### DIFF
--- a/usr/bin/rockpi-sata/misc.py
+++ b/usr/bin/rockpi-sata/misc.py
@@ -209,7 +209,7 @@ def get_interface_tx_info(interface):
 
 
 def delete_disk_partition_number(disk):
-    if "sd" in disk:
+    if "sd" in disk and any(char.isdigit() for char in disk):
         disk = disk[:-1]
     return disk
 


### PR DESCRIPTION
Now it's checking is there any number which we have to delete.

Examples (before this fix):
Input: sda
Output: sd

Input: sda1
Output: sda

Examples (after this fix):
Input: sda
Output: sda

Input: sda1
Output: sda