### PR TITLE
systemd unit should require pigpiod.service

### DIFF
--- a/lib/systemd/system/rockpi-sata.service
+++ b/lib/systemd/system/rockpi-sata.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Rockpi SATA Hat
 After=pigpiod.service
+Requires=pigpiod.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
The systemd unit needs a requirement for `pigpiod.service` additional to the `After`

Implements #5