### PR TITLE
feat(lib/systemd/system/rockpi-sata.service): use syslog as output

### DIFF
--- a/lib/systemd/system/rockpi-sata.service
+++ b/lib/systemd/system/rockpi-sata.service
@@ -8,6 +8,9 @@ ExecStart=/usr/bin/python3 /usr/bin/rockpi-sata/main.py on
 ExecStop=/usr/bin/python3 /usr/bin/rockpi-sata/main.py off
 Restart=on-failure
 WorkingDirectory=/usr/bin/rockpi-sata
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=rockpi-sata
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This writes everything the called script outputs on `STDOUT` and `STDERR` to
syslog.